### PR TITLE
Guard clipboard access against empty clip

### DIFF
--- a/sddl_sdk/src/main/java/com/simplelink/sddl_sdk/SDDLSDK.kt
+++ b/sddl_sdk/src/main/java/com/simplelink/sddl_sdk/SDDLSDK.kt
@@ -38,14 +38,15 @@ object SDDLSDK {
         if (firstSegment != null) return firstSegment
 
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val clip = clipboard.primaryClip
+
+        val clipText = clipboard.primaryClip
+            ?.takeIf { it.itemCount > 0 }
             ?.getItemAt(0)
             ?.coerceToText(context)
             ?.toString()
             ?.trim()
-            .orEmpty()
 
-        return clip.takeIf { c ->
+        return clipText?.takeIf { c ->
             c.length in 4..64 &&
                     c.matches(Regex("^[a-zA-Z0-9_-]+$"))
         }


### PR DESCRIPTION
## Summary
- Avoid IndexOutOfBoundsException when reading from the clipboard by verifying that clip data has at least one item before accessing it.

## Testing
- `./gradlew sddl_sdk:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894eb6d55248330a7501a75d0402c4d