### PR TITLE
Use safe clipboard access in extractIdentifier

### DIFF
--- a/sddl_sdk/src/main/java/com/simplelink/sddl_sdk/SDDLSDK.kt
+++ b/sddl_sdk/src/main/java/com/simplelink/sddl_sdk/SDDLSDK.kt
@@ -37,7 +37,8 @@ object SDDLSDK {
             }
         if (firstSegment != null) return firstSegment
 
-        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+            ?: return null
         val clip = clipboard.primaryClip
             ?.getItemAt(0)
             ?.coerceToText(context)


### PR DESCRIPTION
## Summary
- Safely retrieve clipboard by using a nullable cast and returning early if unavailable

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed0758548330afa40bd227ddc032