### PR TITLE
Add extractIdentifier unit tests

### DIFF
--- a/sddl_sdk/build.gradle.kts
+++ b/sddl_sdk/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
 
     testImplementation(libs.junit)
+    testImplementation("org.mockito:mockito-core:5.11.0")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/sddl_sdk/src/test/java/com/simplelink/sddl_sdk/ExampleUnitTest.kt
+++ b/sddl_sdk/src/test/java/com/simplelink/sddl_sdk/ExampleUnitTest.kt
@@ -1,8 +1,12 @@
 package com.simplelink.sddl_sdk
 
-import org.junit.Test
-
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.net.Uri
 import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.Mockito
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -10,8 +14,40 @@ import org.junit.Assert.*
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 class ExampleUnitTest {
+
+    private fun invokeExtractIdentifier(context: Context, uri: Uri?): String? {
+        val method = SDDLSDK::class.java.getDeclaredMethod(
+            "extractIdentifier",
+            Context::class.java,
+            Uri::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(SDDLSDK, context, uri) as String?
+    }
+
     @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+    fun extractIdentifier_returnsSegmentFromUri() {
+        val context = Mockito.mock(Context::class.java)
+        val uri = Uri.parse("https://example.com/validId")
+
+        val result = invokeExtractIdentifier(context, uri)
+
+        assertEquals("validId", result)
+    }
+
+    @Test
+    fun extractIdentifier_invalidInputReturnsNull() {
+        val context = Mockito.mock(Context::class.java)
+        val clipboard = Mockito.mock(ClipboardManager::class.java)
+        val clipData = ClipData.newPlainText("label", "bad!")
+
+        Mockito.`when`(context.getSystemService(Context.CLIPBOARD_SERVICE)).thenReturn(clipboard)
+        Mockito.`when`(clipboard.primaryClip).thenReturn(clipData)
+
+        val uri = Uri.parse("https://example.com/!!!")
+
+        val result = invokeExtractIdentifier(context, uri)
+
+        assertNull(result)
     }
 }


### PR DESCRIPTION
## Summary
- replace placeholder test with unit tests for `extractIdentifier`
- add Mockito dependency for mocking clipboard and context

## Testing
- `./gradlew :sddl_sdk:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ec8bc8fc833097a4a182d04fa683